### PR TITLE
feat: add new env public node url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The faucet makes use of environment variables for configuration.
 | WALLET_SECRET_KEY    | A hex formatted string of the wallet private key that owns some tokens. |
 | FUEL_NODE_URL        | The GraphQL endpoint for connecting to fuel-core.                       |
 | PUBLIC_FUEL_NODE_URL | The public GraphQL endpoint for connecting to fuel-core. Ex.: https://node.fuel.network/graphql |
-| PORT         | The port the service will listen for http connections on.               |
+| SERVICE_PORT         | The port the service will listen for http connections on.               |
 | DISPENSE_AMOUNT      | Dispense amount on each faucet                                          |
 | MIN_GAS_PRICE        | The minimum gas price to use in each transfer                           |
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The faucet makes use of environment variables for configuration.
 | CAPTCHA_SECRET       | The secret key used for enabling Google captcha authentication.         |
 | WALLET_SECRET_KEY    | A hex formatted string of the wallet private key that owns some tokens. |
 | FUEL_NODE_URL        | The GraphQL endpoint for connecting to fuel-core.                       |
-| SERVICE_PORT         | The port the service will listen for http connections on.               |
+| PUBLIC_FUEL_NODE_URL | The public GraphQL endpoint for connecting to fuel-core. Ex.: https://node.fuel.network/graphql |
+| PORT         | The port the service will listen for http connections on.               |
 | DISPENSE_AMOUNT      | Dispense amount on each faucet                                          |
 | MIN_GAS_PRICE        | The minimum gas price to use in each transfer                           |
 

--- a/deployment/charts/templates/fuel-faucet-deploy.yaml
+++ b/deployment/charts/templates/fuel-faucet-deploy.yaml
@@ -68,6 +68,8 @@ spec:
           {{- end }}
             - name: FUEL_NODE_URL
               value: "{{ .Values.app.node_url }}"
+            - name: PUBLIC_FUEL_NODE_URL
+              value: "{{ .Values.app.public_node_url }}"
           {{- if .Values.app.max_dispenses_per_minute }}
             - name: MAX_DISPENSES_PER_MINUTE
               value: "{{ .Values.app.max_dispenses_per_minute }}"

--- a/deployment/charts/values.yaml
+++ b/deployment/charts/values.yaml
@@ -10,6 +10,7 @@ app:
   wallet_secret_key: "${fuel_faucet_wallet_secret_key}"
   captcha_secret: "${fuel_faucet_captcha_secret}"
   node_url: "${fuel_faucet_node_url}"
+  public_node_url: "${fuel_faucet_public_node_url}"
   max_dispenses_per_minute: "${fuel_faucet_max_dispenses_per_minute}"
   dispense_amount: "${fuel_faucet_dispense_amount}"
   min_gas_price: "${fuel_faucet_min_gas_price}"

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -9,6 +9,7 @@ fuel_faucet_human_logging="false"
 fuel_faucet_wallet_secret_key="random"
 fuel_faucet_captcha_secret="fuelrocks"
 fuel_faucet_node_url="node.example.com"
+fuel_faucet_public_node_url="https://node.example.com/graphql"
 fuel_faucet_max_dispenses_per_minute=20
 fuel_faucet_min_gas_price=0
 fuel_faucet_dispense_amount=10000

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,8 @@
 use crate::constants::{
     CAPTCHA_SECRET, DEFAULT_FAUCET_DISPENSE_AMOUNT, DEFAULT_MAX_DISPENSES_PER_MINUTE,
     DEFAULT_NODE_URL, DEFAULT_PORT, DISPENSE_AMOUNT, FAUCET_ASSET_ID, FUEL_NODE_URL, HUMAN_LOGGING,
-    LOG_FILTER, MAX_DISPENSES_PER_MINUTE, MIN_GAS_PRICE, SERVICE_PORT, WALLET_SECRET_KEY,
+    LOG_FILTER, MAX_DISPENSES_PER_MINUTE, MIN_GAS_PRICE, PUBLIC_FUEL_NODE_URL, SERVICE_PORT,
+    WALLET_SECRET_KEY,
 };
 use fuel_types::AssetId;
 use secrecy::Secret;
@@ -14,6 +15,7 @@ pub struct Config {
     pub service_port: u16,
     pub captcha_secret: Option<Secret<String>>,
     pub node_url: String,
+    pub public_node_url: String,
     pub wallet_secret_key: Option<Secret<String>>,
     pub dispense_amount: u64,
     pub dispense_asset_id: AssetId,
@@ -32,6 +34,8 @@ impl Default for Config {
             captcha_secret: env::var_os(CAPTCHA_SECRET)
                 .map(|s| Secret::new(s.into_string().unwrap())),
             node_url: env::var(FUEL_NODE_URL).unwrap_or_else(|_| DEFAULT_NODE_URL.to_string()),
+            public_node_url: env::var(PUBLIC_FUEL_NODE_URL)
+                .unwrap_or_else(|_| DEFAULT_NODE_URL.to_string()),
             wallet_secret_key: env::var_os(WALLET_SECRET_KEY)
                 .map(|s| Secret::new(s.into_string().unwrap())),
             dispense_amount: env::var(DISPENSE_AMOUNT)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,6 +4,7 @@ pub const LOG_FILTER: &str = "RUST_LOG";
 pub const HUMAN_LOGGING: &str = "HUMAN_LOGGING";
 pub const CAPTCHA_SECRET: &str = "CAPTCHA_SECRET";
 pub const WALLET_SECRET_KEY: &str = "WALLET_SECRET_KEY";
+pub const PUBLIC_FUEL_NODE_URL: &str = "PUBLIC_FUEL_NODE_URL";
 pub const WALLET_SECRET_DEV_KEY: &str =
     "99ad179d4f892ff3124ccd817408ff8a4452d9c16bb1b4968b8a59797e13cd7a";
 pub const FUEL_NODE_URL: &str = "FUEL_NODE_URL";

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -22,7 +22,7 @@ lazy_static::lazy_static! {
 }
 
 #[memoize::memoize]
-pub fn render_page(node_url: String) -> String {
+pub fn render_page(public_node_url: String) -> String {
     let template = include_str!(concat!(env!("OUT_DIR"), "/index.html"));
     // sub in values
     let mut handlebars = Handlebars::new();
@@ -31,14 +31,14 @@ pub fn render_page(node_url: String) -> String {
         .unwrap();
     let mut data = BTreeMap::new();
     data.insert("page_title", "Fuel Faucet");
-    data.insert("node_url", node_url.as_str());
+    data.insert("public_node_url", public_node_url.as_str());
     // render page
     handlebars.render("index", &data).unwrap()
 }
 
 pub async fn main(Extension(config): Extension<SharedConfig>) -> Html<String> {
-    let node_url = config.node_url.clone();
-    Html(render_page(node_url))
+    let public_node_url = config.public_node_url.clone();
+    Html(render_page(public_node_url))
 }
 
 pub async fn health() -> Json<serde_json::Value> {

--- a/static/index.html
+++ b/static/index.html
@@ -11,7 +11,7 @@
     <script src="https://www.google.com/recaptcha/api.js"></script>
     <script>
       const faucetApp = (function () {
-        let providerUrl = "{{ node_url }}";
+        let providerUrl = "{{ public_node_url }}";
         let blockExplorer = "https://fuellabs.github.io/block-explorer-v2";
 
         function give_me_coins(form) {
@@ -244,6 +244,6 @@
         <a href="#" id="explorer-link" class="button">See on Fuel Explorer</a>
       </div>
     </div>
-    <div class="provider-url">Node url: {{ node_url }}</div>
+    <div class="provider-url">Node url: {{ public_node_url }}</div>
   </body>
 </html>


### PR DESCRIPTION
Add a new env config to set the public node URL. This is used to correctly inform the node URL on the faucet page.