### PR TITLE
ping fuel-core health endpoint on health check

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ fn init_logger(config: &Config) {
 
     let sub = tracing_subscriber::fmt::Subscriber::builder()
         .with_writer(std::io::stderr)
+        .with_line_number(true)
+        .with_file(true)
         .with_env_filter(filter);
 
     if config.human_logging {


### PR DESCRIPTION
This will force k8s to restart the faucet if the connection with the fuel-core node goes stale or stops working for some reason.