### PR TITLE
feat: receive address via query params

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -9,48 +9,6 @@
       rel="stylesheet"
     />
     <script src="https://www.google.com/recaptcha/api.js"></script>
-    <script>
-      const faucetApp = (function () {
-        let providerUrl = "{{ public_node_url }}";
-        let blockExplorer = "https://fuellabs.github.io/block-explorer-v2";
-
-        function give_me_coins(form) {
-          let address = form["address"].value;
-          let captcha = form["g-recaptcha-response"].value;
-          let xhr = new XMLHttpRequest();
-          xhr.open("POST", "/dispense");
-          xhr.setRequestHeader("Accept", "application/json");
-          xhr.setRequestHeader("Content-Type", "application/json");
-          xhr.onload = () =>
-            handle_response(address)(JSON.parse(xhr.responseText));
-
-          let data = {
-            address,
-            captcha,
-          };
-          xhr.send(JSON.stringify(data));
-        }
-
-        function handle_response(address) {
-          return function (data) {
-            if (!data.error) {
-              document.getElementById("form").hidden = true;
-              document.getElementById("response").style.display = "block";
-              document.getElementById(
-                "explorer-link"
-              ).href = `${blockExplorer}/address/${address}?providerUrl=${encodeURIComponent(
-                providerUrl
-              )}`;
-            } else {
-              document.getElementById("response-failure").innerText =
-                data.error;
-            }
-          };
-        }
-
-        return { give_me_coins: give_me_coins };
-      })();
-    </script>
   </head>
   <style>
     * {
@@ -245,5 +203,56 @@
       </div>
     </div>
     <div class="provider-url">Node url: {{ public_node_url }}</div>
+    <script>
+      const faucetApp = (function () {
+        let providerUrl = "{{ public_node_url }}";
+        let blockExplorer = "https://fuellabs.github.io/block-explorer-v2";
+        let query = params = new URLSearchParams(document.location.search);
+        let address = query.get('address');
+
+        if (address) {
+          let $address = document.getElementById('address');
+          if ($address) {
+            $address.value = address;
+          }
+        }
+
+        function give_me_coins(form) {
+          let address = form["address"].value;
+          let captcha = form["g-recaptcha-response"].value;
+          let xhr = new XMLHttpRequest();
+          xhr.open("POST", "/dispense");
+          xhr.setRequestHeader("Accept", "application/json");
+          xhr.setRequestHeader("Content-Type", "application/json");
+          xhr.onload = () =>
+            handle_response(address)(JSON.parse(xhr.responseText));
+
+          let data = {
+            address,
+            captcha,
+          };
+          xhr.send(JSON.stringify(data));
+        }
+
+        function handle_response(address) {
+          return function (data) {
+            if (!data.error) {
+              document.getElementById("form").hidden = true;
+              document.getElementById("response").style.display = "block";
+              document.getElementById(
+                "explorer-link"
+              ).href = `${blockExplorer}/address/${address}?providerUrl=${encodeURIComponent(
+                providerUrl
+              )}`;
+            } else {
+              document.getElementById("response-failure").innerText =
+                data.error;
+            }
+          };
+        }
+
+        return { give_me_coins: give_me_coins };
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Enable address to be fulfilled via query params. Ex.: `http://localhost:3000?address=0x00000000000011111111111`.

Closes: #19 