### PR TITLE
UX: Display wait and error states

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -74,6 +74,10 @@
       justify-content: center;
     }
 
+    .button:disabled {
+      background-color: gray;
+    }
+
     .card {
       margin-top: 90px;
       z-index: 1;
@@ -138,6 +142,32 @@
       margin-top: 10px;
       color: #949494;
     }
+
+    .queued {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      gap: 1rem;
+    }
+
+    .loader {
+      border: 0.4rem solid #f3f3f3;
+      border-top: 0.4rem solid #04aa6d;
+      border-radius: 50%;
+      width: 2rem;
+      height: 2rem;
+      animation: spin 2s linear infinite;
+    }
+
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+
+    .hidden {
+      display: none;
+    }
   </style>
   <body>
     <div class="background"></div>
@@ -193,6 +223,10 @@
             data-sitekey="6Ld3cEwfAAAAAMd4QTs7aO85LyKGdgj0bFsdBfre"
           ></div>
         </div>
+        <div class="queued hidden">
+          <div class="loader"></div>
+          <div>Waiting until more tokens are available</div>
+        </div>
         <br />
         <div id="response-failure"></div>
         <input type="submit" value="Give me Ether" class="button" />
@@ -217,6 +251,18 @@
           }
         }
 
+        function showWaiting() {
+          document.getElementsByClassName("captcha-container")[0].classList.add("hidden");
+          document.getElementsByClassName("queued")[0].classList.remove("hidden");
+          form.querySelector("input[type=submit]").disabled = true;
+        }
+
+        function hideWaiting() {
+          document.getElementsByClassName("captcha-container")[0].classList.remove("hidden");
+          document.getElementsByClassName("queued")[0].classList.add("hidden");
+          form.querySelector("input[type=submit]").disabled = false;
+        }
+
         function give_me_coins(form) {
           let address = form["address"].value;
           let captcha = form["g-recaptcha-response"].value;
@@ -226,14 +272,19 @@
           xhr.setRequestHeader("Content-Type", "application/json");
           xhr.onload = () =>
             handle_response(address)(JSON.parse(xhr.responseText));
+          xhr.onetimeout = () => handle_error("Connection to the server timed out");
+          xhr.onerror = () => handle_error("Connection to the server failed");
 
           let data = {
             address,
             captcha,
           };
           xhr.send(JSON.stringify(data));
-        }
 
+          document.getElementById("response-failure").innerText = "";
+          showWaiting();
+        }
+        
         function handle_response(address) {
           return function (data) {
             if (!data.error) {
@@ -245,10 +296,15 @@
                 providerUrl
               )}`;
             } else {
-              document.getElementById("response-failure").innerText =
-                data.error;
+              document.getElementById("response-failure").innerText = data.error;
+              hideWaiting();
             }
           };
+        }
+
+        function handle_error(message) {
+          document.getElementById("response-failure").innerText = message;
+          hideWaiting();
         }
 
         return { give_me_coins: give_me_coins };


### PR DESCRIPTION
Adds a loading spinner and explanation when request to dispense tokens cannot be completed immediately due to rate limiting. Also displayes proper error messages when the server goes down or there are network issues.

### Screenshot of the loading state

<img width="585" alt="Screenshot of the loading icon" src="https://user-images.githubusercontent.com/2204863/207123457-25676873-fd1c-457d-8b59-5a8b226c6d57.png">

