### PR TITLE
fixed explorer link

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -264,7 +264,7 @@
   <script>
     const faucetApp = (function () {
       let providerUrl = "{{ public_node_url }}";
-      let blockExplorer = "https://app.fuel.network";
+      let blockExplorer = "https://app-testnet.fuel.network";
       let query = params = new URLSearchParams(document.location.search);
       let address = query.get('address');
       let redirectUrl = query.get('redirectUrl');


### PR DESCRIPTION
the current Url for explorer is hardcoded to the mainnet explorer. 

Fixed the url to testnet so that transfer transactions could be visible.

