### PR TITLE
chore(docker): native multi-arch via shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,42 +121,28 @@ jobs:
       - cargo-check
       - cargo-test
     if: (github.event_name == 'release' && github.event.action == 'published') || github.ref == 'refs/heads/master' || github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            ghcr.io/fuellabs/faucet
-          tags: |
-            type=ref,event=branch
-            type=sha,prefix=
-            type=semver,pattern={{raw}}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Log in to the ghcr.io registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push the image to ghcr.io
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: deployment/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: FuelLabs/github-actions/.github/workflows/docker-build-push.yml@master
+    secrets:
+      REGISTRY_USERNAME: ${{ github.repository_owner }}
+      REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      auth-mode: registry-login
+      registry: ghcr.io
+      build-backend: native
+      platforms: linux/amd64,linux/arm64
+      runs-on-amd64: ubuntu-latest
+      runs-on-arm64: ubuntu-24.04-arm
+      dockerfile: deployment/Dockerfile
+      docker-context: .
+      image: ghcr.io/fuellabs/faucet
+      tags: |
+        type=ref,event=branch
+        type=sha,prefix=
+        type=semver,pattern={{raw}}
 
       # - name: Notify if Job Fails
       #   uses: ravsamhq/notify-slack-action@v2


### PR DESCRIPTION
## Summary
- Migrate container builds to `FuelLabs/github-actions/.github/workflows/docker-build-push.yml@master`
- Native multi-arch: `linux/amd64` + `linux/arm64` (`ubuntu-latest` / `ubuntu-24.04-arm`)

## Test plan
- [ ] CI passes on PR (amd64 + arm64 build jobs)
- [ ] Image manifest lists both architectures after merge

Part of DEVOPS-1249 / Move to graviton.

Depends on github-actions `master` with checkout/LFS inputs (DEVOPS-1248).

Made with [Cursor](https://cursor.com)